### PR TITLE
Add google tag manager support with custom pageview event

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # The absolute URL hostname of this application
 NEXT_PUBLIC_HOST=http://localhost:3000
+
+# Analytics
+NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=GTM-XXXX

--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ Styled components provided in styles.css serve to provide a set of basic compone
 ## REACT COMPONENTS
 
 React components are added as a need is recognized to reduce development around commonly recurring component patterns.
+
+## SERVER HEADERS
+
+This codebase makes use of Google Tag Manager for tracking page views and custom events. If you would like to utilize Google Tag Manager alongside a Content Security Policy header, please [refer to the following article](https://developers.google.com/tag-platform/tag-manager/web/csp) from Google.

--- a/src/functions/event-tracking/gtm.js
+++ b/src/functions/event-tracking/gtm.js
@@ -1,0 +1,23 @@
+export const GTM_ID = process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID;
+
+export function pageview(url) {
+  pushToDataLayer({
+    event: 'pageview',
+    page: url,
+  });
+}
+
+export function event(eventName, eventData) {
+  pushToDataLayer({
+    event: eventName,
+    ...eventData,
+  });
+}
+
+function pushToDataLayer(data) {
+  try {
+    window.dataLayer.push(data);
+  } catch {
+    console.warn(`Could not push ${data.event || 'event'} to dataLayer. Is dataLayer initialized?`);
+  }
+}

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -1,5 +1,43 @@
 import './styles.css';
+import Script from 'next/script';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+import { GTM_ID, pageview } from '@/functions/event-tracking/gtm';
 
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  const router = useRouter();
+
+  useEffect(() => {
+    // `routeChangeComplete` won't run for the first page load unless the query string is
+    // hydrated later on, so here we log a page view if this is the first render and
+    // there's no query string
+    if (!router.asPath.includes('?')) {
+      pageview(router.asPath);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // log a pageView on route change
+  useEffect(() => {
+    router.events.on('routeChangeComplete', pageview);
+    return () => {
+      router.events.off('routeChangeComplete', pageview);
+    };
+  }, [router.events]);
+
+  return (
+    <>
+      <Script id="google-tag-manager" strategy="afterInteractive">
+        {`
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','${GTM_ID}');
+      `}
+      </Script>
+      <Component {...pageProps} />
+    </>
+  );
 }

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,4 +1,6 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { GTM_ID } from '@/functions/event-tracking/gtm';
+
 class MyDocument extends Document {
   static async getInitialProps(ctx) {
     const initialProps = await Document.getInitialProps(ctx);
@@ -10,6 +12,14 @@ class MyDocument extends Document {
       <Html lang="en">
         <Head />
         <body>
+          <noscript>
+            <iframe
+              src={`https://www.googletagmanager.com/ns.html?id=${GTM_ID}`}
+              height="0"
+              width="0"
+              style={{ display: 'none', visibility: 'hidden' }}
+            />
+          </noscript>
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
This pull request adds Google Tag Manager support such that users of this starter kit can log page views and custom events.